### PR TITLE
Added function to calculate column emission measure

### DIFF
--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -328,6 +328,15 @@ Timestep #: {self._index}"""
         """
         Computes the column emission measure, where it is assumed that the loop is
         confined to a single pixel and oriented along the LOS
+        
+        # Parameters
+        bins (`astropy.units.Quantity`): temperature bin edges, including rightmost edge. If None (default),
+        the bins will be equally-spaced in $\log{T}$, with a left edge at $\log{T}=3$, a right edge at
+        $\log{T}=8$, and a bin width of $0.05$.
+        
+        # Returns
+        em (`astropy.units.Quantity`): the column emission measure in each bin
+        bins (`astropy.units.Quantity`): temperature bin edges. Note that `len(bins)=len(em)+1`.
         """
         if bins is None:
             bins = 10.0**(np.arange(3.0, 8.0, 0.05)) * u.K

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -324,17 +324,17 @@ Timestep #: {self._index}"""
         return np.average(quantity_bounds, weights=grid_widths_bounds)
 
     def column_emission_measure(self, min_logT=3.0, max_logT=8.0, dlogT = 0.05):
-    """
-    Computes the column emission measure over the whole loop
-    """
-    bins = np.arange(min_logT, max_logT+dlogT, dlogT)
-    N_bins = len(bins)
-    EMc = np.zeros(N_bins) * (u.cm**(-5))
-    indices = np.searchsorted(bins, np.log10(self.electron_temperature.value), side='right')
-    indices = [item-1 for item in indices]
-    for i in range(len(self.coordinate)):
-        EMc[indices[i]] += self.grid_widths[i] * self.electron_density[i] * self.ion_density[i]
-    return(EMc, bins)
+        """
+            Computes the column emission measure over the whole loop
+            """
+        bins = np.arange(min_logT, max_logT+dlogT, dlogT)
+        N_bins = len(bins)
+        EMc = np.zeros(N_bins) * (u.cm**(-5))
+        indices = np.searchsorted(bins, np.log10(self.electron_temperature.value), side='right')
+        indices = [item-1 for item in indices]
+        for i in range(len(self.coordinate)):
+            EMc[indices[i]] += self.grid_widths[i] * self.electron_density[i] * self.ion_density[i]
+        return(EMc, bins)
 
     def peek(self, **kwargs):
         """

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -323,6 +323,19 @@ Timestep #: {self._index}"""
         grid_widths_bounds = self.grid_widths[i_bounds]
         return np.average(quantity_bounds, weights=grid_widths_bounds)
 
+    def column_emission_measure(self, min_logT=3.0, max_logT=8.0, dlogT = 0.05):
+    """
+    Computes the column emission measure over the whole loop
+    """
+    bins = np.arange(min_logT, max_logT+dlogT, dlogT)
+    N_bins = len(bins)
+    EMc = np.zeros(N_bins) * (u.cm**(-5))
+    indices = np.searchsorted(bins, np.log10(self.electron_temperature.value), side='right')
+    indices = [item-1 for item in indices]
+    for i in range(len(self.coordinate)):
+        EMc[indices[i]] += self.grid_widths[i] * self.electron_density[i] * self.ion_density[i]
+    return(EMc, bins)
+
     def peek(self, **kwargs):
         """
         Quick look at profiles at a given timestep.

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -332,7 +332,8 @@ Timestep #: {self._index}"""
         if bins is None:
             bins = 10.0**(np.arange(3.0, 8.0, 0.05)) * u.K
         weights = self.electron_density * self.ion_density * self.grid_widths
-        H, _, _ = np.histogram2d(self.grid_centers, self.electron_temperature, bins=(self.grid_edges, bins), weights=weights)
+        H, _, _ = np.histogram2d(self.grid_centers, self.electron_temperature,
+                                 bins=(self.grid_edges, bins), weights=weights)
         return H.sum(axis=0), bins
 
     def peek(self, **kwargs):


### PR DESCRIPTION
In parse.py, in the Profile class, I've added a function to calculate the column emission measure for a profile snapshot.  

```
from pydrad.parse import Strand
from matplotlib import pyplot as plot
s = Strand('/path/to/sim')
p = s[100]
EMc, bins = p.column_emission_measure()
plot.step(bins, EMc)
plot.yscale('log')
plot.show()
```

etc.  The function uses a default binning range of log T = [3.0,8.0), in steps of dlog T = 0.05.

