### PR TITLE
Include stderr and stdout when throwing error

### DIFF
--- a/pydrad/configure/util.py
+++ b/pydrad/configure/util.py
@@ -36,4 +36,4 @@ def run_shell_command(cmd, cwd, shell=True):
         log.warn(stderr)
     hydrad_error_messages = ['segmentation fault', 'abort', 'error:']
     if any([e in s.lower() for s in [stderr, stdout] for e in hydrad_error_messages]):
-        raise HYDRADError
+        raise HYDRADError(f'{stderr}\n{stdout}')


### PR DESCRIPTION
Make error messages more informative