### PR TITLE
Calculate time array without reading all AMR files

### DIFF
--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -28,7 +28,9 @@ def get_master_time(hydrad_root):
         with open('HYDRAD/config/hydrad.cfg', 'r') as f:
             lines = f.readlines()
         cadence = float(lines[3])
-        time = np.fromiter([i*cadence for i in range(len(amr_files))], dtype='float')
+        with open(amr_files[0]) as f:
+            start_time = float(f.readline())
+        time = np.fromiter([start_time + t * cadence for t in range(len(amr_files))], dtype='float')
     except FileNotFoundError:
         log.debug(f'HYDRAD/config/hydrad.cfg not found')
         time = np.zeros((len(amr_files),))

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -25,16 +25,12 @@ def get_master_time(hydrad_root, read_from_cfg=False):
     amr_files = glob.glob(os.path.join(hydrad_root, 'Results/profile*.amr'))
     if read_from_cfg:
         log.debug('Creating master time array from config files')
-        try:
-            with open(os.path.join(hydrad_root, 'HYDRAD/config/hydrad.cfg'), 'r') as f:
-                lines = f.readlines()
-            cadence = float(lines[3])
-            with open(amr_files[0]) as f:
-                start_time = float(f.readline())
-            time = start_time + np.arange(len(amr_files)) * cadence
-        except FileNotFoundError:
-            log.debug('HYDRAD/config/hydrad.cfg not found')
-            return
+        with open(os.path.join(hydrad_root, 'HYDRAD/config/hydrad.cfg'), 'r') as f:
+            lines = f.readlines()
+        cadence = float(lines[3])
+        with open(amr_files[0]) as f:
+            start_time = float(f.readline())
+        time = start_time + np.arange(len(amr_files)) * cadence
     else:
         log.debug('Reading master time array from all AMR files')
         time = np.zeros((len(amr_files),))

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -21,22 +21,29 @@ from pydrad.visualize import (plot_strand,
 __all__ = ['Strand', 'Profile', 'InitialProfile']
 
 
-def get_master_time(hydrad_root):
-    log.debug('Reading master time array from all AMR files')
+def get_master_time(hydrad_root, read_from_cfg=None):
     amr_files = glob.glob(os.path.join(hydrad_root, 'Results/profile*.amr'))
-    try:
-        with open('HYDRAD/config/hydrad.cfg', 'r') as f:
-            lines = f.readlines()
-        cadence = float(lines[3])
-        with open(amr_files[0]) as f:
-            start_time = float(f.readline())
-        time = np.fromiter([start_time + t * cadence for t in range(len(amr_files))], dtype='float')
-    except FileNotFoundError:
-        log.debug(f'HYDRAD/config/hydrad.cfg not found')
+    if read_from_cfg is None:
+        log.debug('Reading master time array from all AMR files')
         time = np.zeros((len(amr_files),))
         for i, af in enumerate(amr_files):
             with open(af, 'r') as f:
                 time[i] = f.readline()
+    else:
+        log.debug('Creating master time array from config files')
+        try:
+            with open('HYDRAD/config/hydrad.cfg', 'r') as f:
+                lines = f.readlines()
+            cadence = float(lines[3])
+            with open(amr_files[0]) as f:
+                start_time = float(f.readline())
+            time = np.fromiter([start_time + t * cadence for t in range(len(amr_files))], dtype='float')
+        except FileNotFoundError:
+            log.debug('HYDRAD/config/hydrad.cfg not found -- reading AMR instead')
+            time = np.zeros((len(amr_files),))
+            for i, af in enumerate(amr_files):
+                with open(af, 'r') as f:
+                    time[i] = f.readline()
     return sorted(time) * u.s
 
 
@@ -55,7 +62,8 @@ class Strand(object):
         # when slicing.
         self._master_time = kwargs.pop('master_time', None)
         if self._master_time is None:
-            self._master_time = get_master_time(self.hydrad_root)
+            self._master_time = get_master_time(self.hydrad_root,
+                                                read_from_cfg=kwargs.get('read_from_cfg'))
         # NOTE: time is only specified when slicing a Strand. When not
         # slicing, it should be read from the results.
         self._time = kwargs.pop('time', self._master_time)
@@ -207,7 +215,8 @@ class Profile(object):
         self.time = time
         self._master_time = kwargs.get('master_time')
         if self._master_time is None:
-            self._master_time = get_master_time(self.hydrad_root)
+            self._master_time = get_master_time(self.hydrad_root,
+                                                read_from_cfg=kwargs.get('read_from_cfg'))
         # Read results files
         self._read_phy()
         self._read_amr()

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -24,10 +24,17 @@ __all__ = ['Strand', 'Profile', 'InitialProfile']
 def get_master_time(hydrad_root):
     log.debug('Reading master time array from all AMR files')
     amr_files = glob.glob(os.path.join(hydrad_root, 'Results/profile*.amr'))
-    time = np.zeros((len(amr_files),))
-    for i, af in enumerate(amr_files):
-        with open(af, 'r') as f:
-            time[i] = f.readline()
+    try:
+        with open('HYDRAD/config/hydrad.cfg', 'r') as f:
+            lines = f.readlines()
+        cadence = float(lines[3])
+        time = np.fromiter([i*cadence for i in range(len(amr_files))], dtype='float')
+    except FileNotFoundError:
+        log.debug(f'HYDRAD/config/hydrad.cfg not found')
+        time = np.zeros((len(amr_files),))
+        for i, af in enumerate(amr_files):
+            with open(af, 'r') as f:
+                time[i] = f.readline()
     return sorted(time) * u.s
 
 

--- a/pydrad/parse/tests/test_strand.py
+++ b/pydrad/parse/tests/test_strand.py
@@ -45,6 +45,12 @@ def test_has_quantity(strand, quantity):
         assert isinstance(getattr(p, quantity), u.Quantity)
 
 
+def test_time_arrays_same(hydrad, strand):
+    """Check that reading time arrays different ways yields same answer"""
+    strand2 = Strand(hydrad, read_from_cfg=True)
+    assert u.allclose(strand.time, strand2.time, rtol=0.0, atol=1e-5*u.s)
+
+
 def test_to_hdf5(strand, tmp_path):
     filename = tmp_path / 'hydrad_results.h5'
     strand.to_hdf5(filename, *VAR_NAMES)

--- a/pydrad/parse/tests/test_strand.py
+++ b/pydrad/parse/tests/test_strand.py
@@ -48,7 +48,7 @@ def test_has_quantity(strand, quantity):
 def test_time_arrays_same(hydrad, strand):
     """Check that reading time arrays different ways yields same answer"""
     strand2 = Strand(hydrad, read_from_cfg=True)
-    assert u.allclose(strand.time, strand2.time, rtol=0.0, atol=1e-5*u.s)
+    assert u.allclose(strand.time, strand2.time, rtol=0.0, atol=1e-2*u.s)
 
 
 def test_to_hdf5(strand, tmp_path):


### PR DESCRIPTION
Fixes #132 

This is an attempt to calculate the time array without reading all AMR files (#132), so that initializing a strand is much faster.  It defaults to the original method of reading all the files.

I tested it on simulations with three different cadences and end times and it seems to work.  It grabs the time of the first profile, and then uses the cadence to create the full time array.  The strand initializes instantly.  

It assumes that there are no missing files, and that the cadence does not change in the middle of a simulation.  These seem like fringe cases, though.  