### PR TITLE
Add option for specifying minimum cells

### DIFF
--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -410,8 +410,8 @@ class Configure(object):
         Minimum allowed number of grid cells,
         $n_{min}=\lceil L/\Delta s_{max}\\rceil$, where $L$ is the loop
         length and $\Delta s_{max}$ is the maximum allowed grid cell width.
-        Optionally, if the number of maximum cells is specified
-        in ``config['grid']['maximum_cells']``, this value will take
+        Optionally, if the minimum number of cells is specified
+        in ``config['grid']['minimum_cells']``, this value will take
         precedence.
         """
         if 'minimum_cells' in self.config['grid']:
@@ -429,7 +429,7 @@ class Configure(object):
         Maximum allowed number of grid cells,
         $n_{max}=\lfloor 2^{L_R}n_{min}\\rfloor$, where $L_R$ is the maximum
         refinement level and $n_{min}$ is the minimum allowed number of
-        grid cells. Optionally, if the number of maximum cells is specified
+        grid cells. Optionally, if the maximum number of cells is specified
         in ``config['grid']['maximum_cells']``, this value will take
         precedence.
         """

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -410,13 +410,18 @@ class Configure(object):
         Minimum allowed number of grid cells,
         $n_{min}=\lceil L/\Delta s_{max}\\rceil$, where $L$ is the loop
         length and $\Delta s_{max}$ is the maximum allowed grid cell width.
+        Optionally, if the number of maximum cells is specified
+        in ``config['grid']['maximum_cells']``, this value will take
+        precedence.
         """
+        if 'minimum_cells' in self.config['grid']:
+            return int(self.config['grid']['minimum_cells'])
         n_min = self.config['general']['loop_length'] / self.config['grid']['maximum_cell_width']
         if n_min.decompose().unit != u.dimensionless_unscaled:
             raise u.UnitConversionError(
                 f'''Maximum cell width must be able to be converted to 
                 {self.config['general']['loop_length'].unit}''')
-        return int(np.ceil(n_min.decompose()))
+        return int(np.round(n_min.decompose()))
 
     @property
     def maximum_cells(self):
@@ -425,7 +430,7 @@ class Configure(object):
         $n_{max}=\lfloor 2^{L_R}n_{min}\\rfloor$, where $L_R$ is the maximum
         refinement level and $n_{min}$ is the minimum allowed number of
         grid cells. Optionally, if the number of maximum cells is specified
-        in in ``config['grid']['maximum_cells']``, this value will take
+        in ``config['grid']['maximum_cells']``, this value will take
         precedence.
         """
         if 'maximum_cells' in self.config['grid']:


### PR DESCRIPTION
This adds the ability to explicitly specify the minimum number of cells as opposed to calculating it from the max cell width