### PR TITLE
Fix Windows compatibility in configure.py

### DIFF
--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -6,7 +6,6 @@ import copy
 import datetime
 import tempfile
 import shutil
-
 from distutils.dir_util import copy_tree
 
 import numpy as np
@@ -128,15 +127,15 @@ class Configure(object):
                 f.write(filestring)
         # NOTE: make sure we have needed permissions to run compile script
 		# Only do this on Unix-based systems
-        if not on_windows:
+        if not on_windows():
             run_shell_command(
                 ['chmod', 'u+x', 'build_initial_conditions.bat'],
                 os.path.join(root_dir, 'Initial_Conditions/build_scripts'),
                 shell=False
             )
         run_shell_command(
-		['./build_initial_conditions.bat'],
-		os.path.join(root_dir, 'Initial_Conditions/build_scripts')
+		    ['./build_initial_conditions.bat'],
+		    os.path.join(root_dir, 'Initial_Conditions/build_scripts')
         )
         if not os.path.exists(os.path.join(root_dir,
                                            'Initial_Conditions/profiles')):
@@ -204,15 +203,15 @@ class Configure(object):
             build_script = 'build_HYDRAD.bat'
         # NOTE: make sure we have needed permissions to run compile script
 		# Only do this on Unix-based systems (chmod not valid on Windows)
-        if not on_windows:
+        if not on_windows():
             run_shell_command(
                 ['chmod', 'u+x', build_script],
                 os.path.join(root_dir, 'HYDRAD/build_scripts'),
                 shell=False,
             )
         run_shell_command(
-		[f'./{build_script}'],
-		os.path.join(root_dir, 'HYDRAD/build_scripts'),
+		    [f'./{build_script}'],
+		    os.path.join(root_dir, 'HYDRAD/build_scripts'),
         )
         if not os.path.exists(os.path.join(root_dir, 'Results')):
             os.mkdir(os.path.join(root_dir, 'Results'))
@@ -447,5 +446,3 @@ class Configure(object):
                 {self.config['general']['loop_length'].unit}''')
         return int(np.floor(
             2**self.config['grid']['maximum_refinement_level'] * n_min))
-
-

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -128,35 +128,24 @@ class Configure(object):
                 f.write(filestring)
         # NOTE: make sure we have needed permissions to run compile script
 		# Only do this on Unix-based systems
-        if platform.system() != 'Windows':
+        if not self.on_windows:
             run_shell_command(
                 ['chmod', 'u+x', 'build_initial_conditions.bat'],
                 os.path.join(root_dir, 'Initial_Conditions/build_scripts'),
                 shell=False
             )
-            run_shell_command(
-                ['./build_initial_conditions.bat'],
-                os.path.join(root_dir, 'Initial_Conditions/build_scripts')
-            )
-        else:
-            run_shell_command(
-                ['build_initial_conditions.bat'],
-                os.path.join(root_dir, 'Initial_Conditions/build_scripts')
-            )
+        run_shell_command(
+			['./build_initial_conditions.bat'],
+			os.path.join(root_dir, 'Initial_Conditions/build_scripts')
+        )
         if not os.path.exists(os.path.join(root_dir,
                                            'Initial_Conditions/profiles')):
             os.mkdir(os.path.join(root_dir, 'Initial_Conditions/profiles'))
         if execute:
-            if platform.system() != 'Windows':
-                run_shell_command(
-                    ['./Initial_Conditions.exe'],
-                    root_dir,
-                )
-            else:
-                run_shell_command(
-                    ['Initial_Conditions.exe'],
-                    root_dir,
-                )
+            run_shell_command(
+                ['./Initial_Conditions.exe'],
+                root_dir,
+            )
             if self.config['heating']['background'].get('use_initial_conditions', False):
                 self.equilibrium_heating_rate = self.get_equilibrium_heating_rate(root_dir)
 
@@ -214,22 +203,17 @@ class Configure(object):
         else:
             build_script = 'build_HYDRAD.bat'
         # NOTE: make sure we have needed permissions to run compile script
-		# Only do this on Unix-based systems
-        if platform.system() != 'Windows':
+		# Only do this on Unix-based systems (chmod not valid on Windows)
+        if not self.on_windows:
             run_shell_command(
                 ['chmod', 'u+x', build_script],
                 os.path.join(root_dir, 'HYDRAD/build_scripts'),
                 shell=False,
             )
-            run_shell_command(
-                [f'./{build_script}'],
-                os.path.join(root_dir, 'HYDRAD/build_scripts'),
-            )
-        else:
-            run_shell_command(
-                [f'{build_script}'],
-                os.path.join(root_dir, 'HYDRAD/build_scripts'),
-            )
+        run_shell_command(
+			[f'./{build_script}'],
+			os.path.join(root_dir, 'HYDRAD/build_scripts'),
+        )
         if not os.path.exists(os.path.join(root_dir, 'Results')):
             os.mkdir(os.path.join(root_dir, 'Results'))
 
@@ -463,3 +447,10 @@ class Configure(object):
                 {self.config['general']['loop_length'].unit}''')
         return int(np.floor(
             2**self.config['grid']['maximum_refinement_level'] * n_min))
+
+    @property
+    def on_windows(self):
+        """
+        Determine whether the user's operating system is Windows
+        """
+        return platform.system().lower() == 'windows'

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -211,8 +211,8 @@ class Configure(object):
                 shell=False,
             )
         run_shell_command(
-			[f'./{build_script}'],
-			os.path.join(root_dir, 'HYDRAD/build_scripts'),
+		[f'./{build_script}'],
+		os.path.join(root_dir, 'HYDRAD/build_scripts'),
         )
         if not os.path.exists(os.path.join(root_dir, 'Results')):
             os.mkdir(os.path.join(root_dir, 'Results'))

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -135,8 +135,8 @@ class Configure(object):
                 shell=False
             )
         run_shell_command(
-			['./build_initial_conditions.bat'],
-			os.path.join(root_dir, 'Initial_Conditions/build_scripts')
+		['./build_initial_conditions.bat'],
+		os.path.join(root_dir, 'Initial_Conditions/build_scripts')
         )
         if not os.path.exists(os.path.join(root_dir,
                                            'Initial_Conditions/profiles')):

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import tempfile
 import shutil
+import platform
 from distutils.dir_util import copy_tree
 
 import numpy as np
@@ -126,23 +127,36 @@ class Configure(object):
             with open(os.path.join(root_dir, filename), 'w') as f:
                 f.write(filestring)
         # NOTE: make sure we have needed permissions to run compile script
-        run_shell_command(
-            ['chmod', 'u+x', 'build_initial_conditions.bat'],
-            os.path.join(root_dir, 'Initial_Conditions/build_scripts'),
-            shell=False
-        )
-        run_shell_command(
-            ['./build_initial_conditions.bat'],
-            os.path.join(root_dir, 'Initial_Conditions/build_scripts')
-        )
+		# Only do this on Unix-based systems
+        if platform.system() != 'Windows':
+            run_shell_command(
+                ['chmod', 'u+x', 'build_initial_conditions.bat'],
+                os.path.join(root_dir, 'Initial_Conditions/build_scripts'),
+                shell=False
+            )
+            run_shell_command(
+                ['./build_initial_conditions.bat'],
+                os.path.join(root_dir, 'Initial_Conditions/build_scripts')
+            )
+        else:
+            run_shell_command(
+                ['build_initial_conditions.bat'],
+                os.path.join(root_dir, 'Initial_Conditions/build_scripts')
+            )
         if not os.path.exists(os.path.join(root_dir,
                                            'Initial_Conditions/profiles')):
             os.mkdir(os.path.join(root_dir, 'Initial_Conditions/profiles'))
         if execute:
-            run_shell_command(
-                ['./Initial_Conditions.exe'],
-                root_dir,
-            )
+            if platform.system() != 'Windows':
+                run_shell_command(
+                    ['./Initial_Conditions.exe'],
+                    root_dir,
+                )
+            else:
+                run_shell_command(
+                    ['Initial_Conditions.exe'],
+                    root_dir,
+                )
             if self.config['heating']['background'].get('use_initial_conditions', False):
                 self.equilibrium_heating_rate = self.get_equilibrium_heating_rate(root_dir)
 
@@ -200,15 +214,22 @@ class Configure(object):
         else:
             build_script = 'build_HYDRAD.bat'
         # NOTE: make sure we have needed permissions to run compile script
-        run_shell_command(
-            ['chmod', 'u+x', build_script],
-            os.path.join(root_dir, 'HYDRAD/build_scripts'),
-            shell=False,
-        )
-        run_shell_command(
-            [f'./{build_script}'],
-            os.path.join(root_dir, 'HYDRAD/build_scripts'),
-        )
+		# Only do this on Unix-based systems
+        if platform.system() != 'Windows':
+            run_shell_command(
+                ['chmod', 'u+x', build_script],
+                os.path.join(root_dir, 'HYDRAD/build_scripts'),
+                shell=False,
+            )
+            run_shell_command(
+                [f'./{build_script}'],
+                os.path.join(root_dir, 'HYDRAD/build_scripts'),
+            )
+        else:
+            run_shell_command(
+                [f'{build_script}'],
+                os.path.join(root_dir, 'HYDRAD/build_scripts'),
+            )
         if not os.path.exists(os.path.join(root_dir, 'Results')):
             os.mkdir(os.path.join(root_dir, 'Results'))
 

--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -6,7 +6,7 @@ import copy
 import datetime
 import tempfile
 import shutil
-import platform
+
 from distutils.dir_util import copy_tree
 
 import numpy as np
@@ -15,7 +15,7 @@ from jinja2 import Environment, PackageLoader, ChoiceLoader, DictLoader
 import asdf
 
 from . import filters
-from .util import run_shell_command
+from .util import run_shell_command, on_windows
 
 __all__ = ['Configure']
 
@@ -128,7 +128,7 @@ class Configure(object):
                 f.write(filestring)
         # NOTE: make sure we have needed permissions to run compile script
 		# Only do this on Unix-based systems
-        if not self.on_windows:
+        if not on_windows:
             run_shell_command(
                 ['chmod', 'u+x', 'build_initial_conditions.bat'],
                 os.path.join(root_dir, 'Initial_Conditions/build_scripts'),
@@ -204,7 +204,7 @@ class Configure(object):
             build_script = 'build_HYDRAD.bat'
         # NOTE: make sure we have needed permissions to run compile script
 		# Only do this on Unix-based systems (chmod not valid on Windows)
-        if not self.on_windows:
+        if not on_windows:
             run_shell_command(
                 ['chmod', 'u+x', build_script],
                 os.path.join(root_dir, 'HYDRAD/build_scripts'),
@@ -448,9 +448,4 @@ class Configure(object):
         return int(np.floor(
             2**self.config['grid']['maximum_refinement_level'] * n_min))
 
-    @property
-    def on_windows(self):
-        """
-        Determine whether the user's operating system is Windows
-        """
-        return platform.system().lower() == 'windows'
+

--- a/pydrad/configure/util.py
+++ b/pydrad/configure/util.py
@@ -23,7 +23,7 @@ class HYDRADError(Exception):
 
 def run_shell_command(cmd, cwd, shell=True):
     # remove "./" from commands if the user is working on Windows
-    if platform.system().lower() == 'windows' and cmd[0][0:2] == './':
+    if on_windows() and cmd[0][0:2] == './':
         cmd[0] = cmd[0][2:]
     cmd = subprocess.run(
         cmd,
@@ -41,3 +41,10 @@ def run_shell_command(cmd, cwd, shell=True):
     hydrad_error_messages = ['segmentation fault', 'abort', 'error:']
     if any([e in s.lower() for s in [stderr, stdout] for e in hydrad_error_messages]):
         raise HYDRADError(f'{stderr}\n{stdout}')
+
+def on_windows():
+    """
+    Determine whether the user's operating system is Windows
+    """
+    return platform.system().lower() == 'windows'
+	

--- a/pydrad/configure/util.py
+++ b/pydrad/configure/util.py
@@ -24,7 +24,7 @@ class HYDRADError(Exception):
 def run_shell_command(cmd, cwd, shell=True):
     # remove "./" from commands if the user is working on Windows
     if platform.system().lower() == 'windows' and cmd[0][0:2] == './':
-        cmd = [cmd[0][2:]]
+        cmd[0] = cmd[0][2:]
     cmd = subprocess.run(
         cmd,
         cwd=cwd,

--- a/pydrad/configure/util.py
+++ b/pydrad/configure/util.py
@@ -22,7 +22,7 @@ class HYDRADError(Exception):
 
 
 def run_shell_command(cmd, cwd, shell=True):
-    # remove "./" from commands if the user is working on Windows
+    # Remove "./" from commands if the user is working on Windows
     if on_windows() and cmd[0][0:2] == './':
         cmd[0] = cmd[0][2:]
     cmd = subprocess.run(
@@ -42,9 +42,9 @@ def run_shell_command(cmd, cwd, shell=True):
     if any([e in s.lower() for s in [stderr, stdout] for e in hydrad_error_messages]):
         raise HYDRADError(f'{stderr}\n{stdout}')
 
+
 def on_windows():
     """
     Determine whether the user's operating system is Windows
     """
     return platform.system().lower() == 'windows'
-	

--- a/pydrad/configure/util.py
+++ b/pydrad/configure/util.py
@@ -2,6 +2,7 @@
 Utilities for HYDRAD configuration
 """
 import subprocess
+import platform
 
 from pydrad import log
 
@@ -21,6 +22,9 @@ class HYDRADError(Exception):
 
 
 def run_shell_command(cmd, cwd, shell=True):
+    # remove "./" from commands if the user is working on Windows
+    if platform.system().lower() == 'windows' and cmd[0][0:2] == './':
+        cmd = [cmd[0][2:]]
     cmd = subprocess.run(
         cmd,
         cwd=cwd,


### PR DESCRIPTION
Fixes #139

Fixes the use of `chmod` and `.`, both of which are Unix-based commands and invalid on Windows.  I tested this on Windows 10 and then verified on MacOS that it doesn't break anything.  