### PR TITLE
Fix beam heating and OpenMP options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pydrad
 
-![pydrad CI status](https://github.com/rice-solar-physics/pydrad/workflows/Test/badge.svg)
+[![pydrad CI status](https://github.com/rice-solar-physics/pydrad/workflows/test.yml/badge.svg?branch=main)](https://github.com/rice-solar-physics/pydrad/actions)
 [![Documentation Status](https://readthedocs.org/projects/pydrad/badge/?version=latest)](https://pydrad.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/rice-solar-physics/pydrad/branch/master/graph/badge.svg)](https://codecov.io/gh/rice-solar-physics/pydrad)
 

--- a/conftest.py
+++ b/conftest.py
@@ -126,8 +126,5 @@ def hydrad(tmpdir_factory, hydrad_clean):
     # containing the results.
     hydrad_tmp = tmpdir_factory.mktemp('hydrad_tmp')
     configuration.setup_simulation(hydrad_tmp, hydrad_clean, overwrite=True)
-    pydrad.configure.util.run_shell_command(
-        ['./HYDRAD.exe'],
-        hydrad_tmp,
-    )
+    pydrad.configure.util.run_shell_command(hydrad_tmp / 'HYDRAD.exe')
     return hydrad_tmp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ page = """
     in the config_tables.yml file. Changes to this file will not persist
     after each docs build.
 
-.. _configuration tables:
+.. _configuration-tables:
 
 HYDRAD Configuration Parameters
 ================================

--- a/docs/config_tables.yml
+++ b/docs/config_tables.yml
@@ -72,6 +72,7 @@ General:
   - '``float``'
   - '``bool``'
   - '``bool``'
+  - '``int``'
   - '``bool``'
   - '``bool``'
   Units:
@@ -93,6 +94,7 @@ General:
   - s
   - ''
   - s
+  - ''
   - ''
   - ''
   - ''

--- a/docs/config_tables.yml
+++ b/docs/config_tables.yml
@@ -20,6 +20,7 @@ General:
   - minimum_collisional_coupling_timescale
   - force_single_fluid
   - use_openmp
+  - grid_cells_per_thread
   - open_field
   - force_symmetry
   Description:
@@ -47,6 +48,7 @@ General:
   - If true, force electron and ion quantities to be equal
   - If true, parallelize over threads with `OpenMP <https://www.openmp.org/>`__. This
     option is most useful when including a NLTE chromosphere.
+  - If using OpenMP parallelization, approximate number of grid cells assigned to each thread
   - If true, one footpoint is assumed to not connect to the surface
   - ''
   Type:

--- a/examples/configure_simulation.py
+++ b/examples/configure_simulation.py
@@ -6,7 +6,7 @@ Configure a Simulation
 This example demonstrates the various ways to configure a HYDRAD
 simulation.
 """
-import os
+import pathlib
 import tempfile
 
 import astropy.units as u
@@ -27,7 +27,7 @@ from pydrad.configure.util import get_clean_hydrad
 # Mm loop lasting 5000 s heated by a single 200 s nanoflare
 # solved on an adaptive grid.
 # A complete list of configuration parameters can be found in
-# the `configuration tables`_ page.
+# the `configuration-tables`_ page.
 config_dict = {
     'general': {
         'loop_length': 80*u.Mm,
@@ -139,8 +139,8 @@ print(c.hydrad_header)
 # copy of HYDRAD. You can use a copy you already have locally or
 # use the following convenience function to grab the most recent
 # version from GitHub
-tmpdir = tempfile.mkdtemp()  # Change this to wherever you want to save your clean HYDRAD copy
-hydrad_clean = os.path.join(tmpdir, 'hydrad-clean')
+tmpdir = pathlib.Path(tempfile.mkdtemp())  # Change this to wherever you want to save your clean HYDRAD copy
+hydrad_clean = tmpdir / 'hydrad-clean'
 get_clean_hydrad(hydrad_clean, from_github=True)
 
 #################################################################
@@ -150,7 +150,7 @@ get_clean_hydrad(hydrad_clean, from_github=True)
 # to our new simulation. This function will write all of the needed
 # aforementioned configuration files and run the hydrostatic solver which
 # will provide the initial conditions for the actual simulation.
-c.setup_simulation(os.path.join(tmpdir, 'test-run'), hydrad_clean)
+c.setup_simulation(tmpdir / 'test-run', hydrad_clean)
 
 #################################################################
 # To avoid having to repeatedly setup the configuration dictionary,
@@ -160,7 +160,7 @@ c.setup_simulation(os.path.join(tmpdir, 'test-run'), hydrad_clean)
 # like the config directory and can be easily read and written.
 #
 # To save the configuration to disk and then load it back into a `dict`,
-asdf_config = os.path.join(tmpdir, 'test_config.asdf')
+asdf_config = tmpdir / 'test_config.asdf'
 c.save_config(asdf_config)
 config_from_disk = Configure.load_config(asdf_config)
 print(config_from_disk)

--- a/examples/parse_simulation.py
+++ b/examples/parse_simulation.py
@@ -7,7 +7,7 @@ This example demonstrates how to configure a simple hydrad simulation and
 read in and visualize the outputs as a function of time and field-aligned
 spatial coordinate.
 """
-import os
+import pathlib
 import tempfile
 
 import astropy.units as u
@@ -18,7 +18,7 @@ from pydrad.configure.data import get_defaults
 from pydrad.configure.util import get_clean_hydrad, run_shell_command
 from pydrad.parse import Strand
 
-tmpdir = tempfile.mkdtemp()  # Change to wherever you want to save your clean HYDRAD copy
+tmpdir = pathlib.Path(tempfile.mkdtemp())  # Change to wherever you want to save your clean HYDRAD copy
 
 
 #################################################################
@@ -38,7 +38,7 @@ tmpdir = tempfile.mkdtemp()  # Change to wherever you want to save your clean HY
 #
 # First, we'll setup a simple HYDRAD run and run the simulation.
 # Grab a new copy of HYDRAD
-hydrad_clean = os.path.join(tmpdir, 'hydrad-clean')
+hydrad_clean = tmpdir / 'hydrad-clean'
 get_clean_hydrad(hydrad_clean, from_github=True)
 
 #################################################################
@@ -71,7 +71,7 @@ config['grid']['maximum_refinement_level'] = 6
 # directly from Python, but this is easily done via the command
 # line as well. This can take a few minutes.
 c = Configure(config)
-hydrad_results = os.path.join(tmpdir, 'steady-run')
+hydrad_results = tmpdir / 'steady-run'
 c.setup_simulation(hydrad_results, hydrad_clean)
 run_shell_command(hydrad_results / 'HYDRAD.exe')
 

--- a/examples/parse_simulation.py
+++ b/examples/parse_simulation.py
@@ -73,7 +73,7 @@ config['grid']['maximum_refinement_level'] = 6
 c = Configure(config)
 hydrad_results = os.path.join(tmpdir, 'steady-run')
 c.setup_simulation(hydrad_results, hydrad_clean)
-run_shell_command(['./HYDRAD.exe'], hydrad_results)
+run_shell_command(hydrad_results / 'HYDRAD.exe')
 
 #################################################################
 # To parse the results of a simulation, we create a `~pydard.parse.Strand`

--- a/pydrad/configure/templates/build_script.bat
+++ b/pydrad/configure/templates/build_script.bat
@@ -1,0 +1,1 @@
+{{ compiler }} {{ flags | join(' ') }} {{ files | join(' ') }} -o {{ executable }}

--- a/pydrad/configure/templates/hydrad.config.h
+++ b/pydrad/configure/templates/hydrad.config.h
@@ -36,7 +36,10 @@
 // **** End of Physics ****
 
 // **** Solver ****
-{% if general.use_openmp %}#define OPENMP{% endif %}
+{% if general.use_openmp -%}
+#define OPENMP
+#define CHUNK_SIZE {{ general.grid_cells_per_thread }}
+{%- endif %}
 #define SAFETY_RADIATION {{ solver.safety_radiation | is_required }}
 #define SAFETY_CONDUCTION {{ solver.safety_conduction | is_required }}
 #define SAFETY_ADVECTION {{ solver.safety_advection | is_required }}

--- a/pydrad/configure/templates/initial_conditions.config.h
+++ b/pydrad/configure/templates/initial_conditions.config.h
@@ -32,7 +32,7 @@
 #define EPSILON {{ solver.epsilon | is_required }}
 
 // **** Grid ****
-{% if grid.adapt -%}#define ADAPT{%- endif %}
+{% if grid.adapt %}#define ADAPT{% endif %}
 #define MIN_CELLS {{ minimum_cells | is_required }}
 #define MAX_CELLS {{ maximum_cells | is_required }}
 #define MAX_REFINEMENT_LEVEL {{ grid.maximum_refinement_level | is_required }}

--- a/pydrad/configure/templates/radiation.config.h
+++ b/pydrad/configure/templates/radiation.config.h
@@ -41,3 +41,11 @@
 #define EPSILON_D {{ solver.epsilon_d | is_required }}
 #define EPSILON_R {{ solver.epsilon_r | is_required }}
 // **** End of Solver ****
+
+{% if heating.beam -%}
+// **** Heating ****
+// This needs to be here because the radiation model is needed when constructing the electron
+// beam and it is not imported anywhere else
+#define BEAM_HEATING
+{%- endif %}
+

--- a/pydrad/configure/tests/test_templates.py
+++ b/pydrad/configure/tests/test_templates.py
@@ -531,6 +531,7 @@ def test_radiation_header(configuration):
 #define EPSILON_D 0.1
 #define EPSILON_R 1.8649415311920072
 // **** End of Solver ****"""
+    assert_ignore_blanks(configuration.radiation_header, header)
 
 
 def test_radiation_config_equilibrium(configuration):

--- a/pydrad/tests/test_hydrad.py
+++ b/pydrad/tests/test_hydrad.py
@@ -26,7 +26,7 @@ def test_beam_heating_run(tmpdir_factory, configuration, hydrad_clean):
 
 
 def test_use_openmp(tmpdir_factory, configuration, hydrad_clean):
-    omp_configuration = Configure(configuration.config, compiler='$CXX')
+    omp_configuration = Configure(configuration.config)
     omp_configuration.config['general']['use_openmp'] = True
     omp_configuration.config['general']['grid_cells_per_thread'] = 10
     hydrad_tmp = tmpdir_factory.mktemp('hydrad_tmp')

--- a/pydrad/tests/test_hydrad.py
+++ b/pydrad/tests/test_hydrad.py
@@ -1,7 +1,10 @@
 """
 Some basic smoke tests for HYDRAD runs for different configurations
 """
+import sys
+
 import astropy.units as u
+import pytest
 
 from pydrad.configure import Configure
 from pydrad.configure.util import run_shell_command
@@ -25,6 +28,8 @@ def test_beam_heating_run(tmpdir_factory, configuration, hydrad_clean):
     assert len(strand) == 6
 
 
+@pytest.mark.xfail(condition='darwin' in sys.platform(),
+                   reason='openmp not included by default on macOS')
 def test_use_openmp(tmpdir_factory, configuration, hydrad_clean):
     omp_configuration = Configure(configuration.config)
     omp_configuration.config['general']['use_openmp'] = True

--- a/pydrad/tests/test_hydrad.py
+++ b/pydrad/tests/test_hydrad.py
@@ -1,0 +1,36 @@
+"""
+Some basic smoke tests for HYDRAD runs for different configurations
+"""
+import astropy.units as u
+
+from pydrad.configure import Configure
+from pydrad.configure.util import run_shell_command
+from pydrad.parse import Strand
+
+
+def test_beam_heating_run(tmpdir_factory, configuration, hydrad_clean):
+    configuration.config['heating']['beam'] = [
+        {
+            'time_start': 10*u.s,
+            'flux': 1e9 * u.Unit('erg cm-2 s-1'),
+            'cut_off': 15 * u.keV,
+            'index': 7,
+        },
+    ]
+    configuration.config['general']['total_time'] = 5 * u.s
+    hydrad_tmp = tmpdir_factory.mktemp('hydrad_tmp')
+    configuration.setup_simulation(hydrad_tmp, hydrad_clean, overwrite=True)
+    run_shell_command(hydrad_tmp / 'HYDRAD.exe')
+    strand = Strand(hydrad_tmp)
+    assert len(strand) == 6
+
+
+def test_use_openmp(tmpdir_factory, configuration, hydrad_clean):
+    omp_configuration = Configure(configuration.config, compiler='$CXX')
+    omp_configuration.config['general']['use_openmp'] = True
+    omp_configuration.config['general']['grid_cells_per_thread'] = 10
+    hydrad_tmp = tmpdir_factory.mktemp('hydrad_tmp')
+    omp_configuration.setup_simulation(hydrad_tmp, hydrad_clean, overwrite=True)
+    run_shell_command(hydrad_tmp / 'HYDRAD.exe')
+    strand = Strand(hydrad_tmp)
+    assert len(strand) == 3

--- a/pydrad/tests/test_hydrad.py
+++ b/pydrad/tests/test_hydrad.py
@@ -28,8 +28,8 @@ def test_beam_heating_run(tmpdir_factory, configuration, hydrad_clean):
     assert len(strand) == 6
 
 
-@pytest.mark.xfail(condition='darwin' in sys.platform(),
-                   reason='openmp not included by default on macOS')
+@pytest.mark.xfail(condition='darwin' in sys.platform,
+                   reason='OpenMP not included by default on macOS')
 def test_use_openmp(tmpdir_factory, configuration, hydrad_clean):
     omp_configuration = Configure(configuration.config)
     omp_configuration.config['general']['use_openmp'] = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,17 +34,15 @@ install_requires =
     asdf-astropy
     h5py
     plasmapy
+    GitPython
 
 [options.extras_require]
 test =
-    flake8
-    GitPython
     pillow
     pytest
     pytest-astropy
     pytest-cov
 docs =
-    GitPython
     sphinx
     sphinx-automodapi
     sphinx-changelog


### PR DESCRIPTION
This pull request contains two major bugfixes:

1. Add full support for parallelized  runs with OpenMP (Fixes #163, Fixes #152)
2. Fixes a bug when using the beam heating option by adding the `BEAM_HEATING` directive to the necessary header file.

Additionally, this PR also contains a few other more minor fixes:

1. The compiler script is now configured at runtime. This makes it easier to specify a compiler besides g++. Flags (e.g. for optimization) can also be optionally passed in.
2. The `run_shell_command` function now just takes in a path (Fixes #162)
3. There are now a few additional tests for running HYDRAD with different options. These are just "smoke tests" to ensure that certain combinations of config parameters don't lead to unexpected behavior.