### PR TITLE
Remove in-place division in polynomial fit

### DIFF
--- a/pydrad/configure/configure.py
+++ b/pydrad/configure/configure.py
@@ -381,8 +381,7 @@ class Configure(object):
         Perform polynomial fit to quantity as a function of field aligned coordinate
         over multiple domains and return fitting coefficients.
         """
-        x /= self.config['general']['loop_length']
-        x = x.decompose().to_value(u.dimensionless_unscaled)
+        x = (x/self.config['general']['loop_length']).to_value(u.dimensionless_unscaled)
         y = y.to_value(target_unit)
         coefficients = []
         minmax = []

--- a/pydrad/parse/parse.py
+++ b/pydrad/parse/parse.py
@@ -173,6 +173,10 @@ Loop length: {self.loop_length.to(u.Mm):.3f}"""
         equations used as initial conditions.
         """
         profile_kwargs = self._profile_kwargs.copy()
+        # NOTE: Ensures that all results are only derived from the AMR file
+        # as the quantities in the phy file for the initial conditions can potentially
+        # have a different shape compared to those from the AMR file.
+        profile_kwargs['read_phy'] = False
         # NOTE: These files do not exist for the initial conditions
         profile_kwargs['read_hstate'] = False
         profile_kwargs['read_ine'] = False
@@ -667,10 +671,6 @@ class InitialProfile(Profile):
     @property
     def _amr_filename(self):
         return self.hydrad_root / 'Initial_Conditions' / 'profiles' / 'initial.amr'
-
-    @property
-    def _phy_filename(self):
-        return self.hydrad_root / 'Initial_Conditions' / 'profiles' / 'initial.amr.phy'
 
 
 def _add_property(name, attr,):


### PR DESCRIPTION
This fixes a bug where the in-place division operation in the polynomial fit function led to the field-aligned coordinate being modified in place. This is an issue if this function is applied more than once when setting up a run.

This also forces the initial conditions profile to always use the AMR files.